### PR TITLE
CSR-1929 Handle 4XX errors & add trailing slash to export API calls

### DIFF
--- a/tap_mailchimp_export/http.py
+++ b/tap_mailchimp_export/http.py
@@ -1,5 +1,4 @@
 import requests
-import singer
 import re
 from singer import metrics
 from .timeout import timeout
@@ -7,9 +6,6 @@ from .schemas import (
     EXPORT_API_PATH_NAMES, V3_API_PATH_NAMES, V3_API_ENDPOINT_NAMES
 )
 import backoff
-
-
-logger = singer.get_logger()
 
 
 FULL_URI = "https://{dc}.api.mailchimp.com/3.0/{v3_endpoint}"

--- a/tap_mailchimp_export/streams.py
+++ b/tap_mailchimp_export/streams.py
@@ -127,11 +127,14 @@ def transform_event(record, campaign, include_sends):
 
     if 'error' in obj.keys():
         raise Exception(record)
+    elif int(obj.get('status', 0)) >= 400:
+        raise Exception(record)
 
     try:
         (email, events), = json.loads(record).items()
     except ValueError:
         events = []
+        email = ''
 
     new_events = []
 


### PR DESCRIPTION
The initial error encountered when running this was:

```
INFO local variable 'email' referenced before assignment
INFO Waiting 30 seconds - then retrying
INFO local variable 'email' referenced before assignment
INFO Waiting 30 seconds - then retrying
INFO local variable 'email' referenced before assignment
```

That was handled with a `try, except` block:

```
    try:
        (email, events), = json.loads(record).items()
    except ValueError:
        events = []
        email = ''
```

The cause of that exception was a response body that was uncaught by current error handling given there was no `error` key:
```
{"type":"https://mailchimp.com/developer/marketing/docs/errors/%22,%22title%22:%22Upgrade Required", "status":"426", "detail":"Your request was made with the HTTP protocol.  Please make your request via HTTPS rather than HTTP"}
```

and the solution to that was to add an additional check for where `status` was >= `400`:
```
    if 'error' in obj.keys():
        raise Exception(record)
    elif int(obj.get('status', 0)) >= 400:
        raise Exception(record)
```

The reason that the mailchimp API was returning `426` is that without a trailing slash on the API endpoint, it returns a a redirect to an `http` endpoint: 

```
$ curl --request POST \
    --url 'https://us10.api.mailchimp.com/export/1.0/campaignSubscriberActivity' \
    --header 'content-type: application\json' \
    --data '{"apikey": "[redacted], "id": "[redacted]", "since": "2022-06-23 00:00:00"}'

# Output:
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://us10.api.mailchimp.com/export/1.0/campaignSubscriberActivity/">here</a>.</p>
</body></html>
```

Simply adding the trailing slash to the end of the URL like so allows a singer extract to run to completion:
```
if not trailing_slash.match(url):
            url = f'{url}/'
```

Working curl request:
```
$ curl --request POST \
    --url 'https://us10.api.mailchimp.com/export/1.0/campaignSubscriberActivity/' \
    --header 'content-type: application\json' \
    --data '{"apikey": "[redacted], "id": "[redacted]", "since": "2022-06-23 00:00:00"}'
```